### PR TITLE
fix: use ChannelIOWam namespace in wam

### DIFF
--- a/wam/index.html
+++ b/wam/index.html
@@ -23,7 +23,7 @@
       src="/src/main.tsx"
     ></script>
     <script>
-      var appearance = getWamData('appearance')
+      var appearance = window.ChannelIOWam.getWamData('appearance')
       if (appearance === 'dark') {
         document.body.style.backgroundColor = '#464748'
       } else {


### PR DESCRIPTION
## What's Changed?

- Use `window.ChannelIOWam` namespace to load the theme of the wam.