### PR TITLE
[AS-2597] feat: migrate Go tutorial to app-sdk

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,143 @@
+# Channel App チュートリアル — Go
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+公式 [Channel App SDK](https://github.com/channel-io/app-sdk) で作る最小構成の end-to-end App
+Store アプリです。SDK が Function registry、schema、command Extension、versioned HTTP route、
+auto-registration、token lifecycle、request signature verification を担当します。
+
+この repository は実行可能な例として使い、contract と設計原則は SDK 文書を参照してください。
+
+- [アプリ開発完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/app-development.md)
+- [Function、Extension、WAM、認証の基本概念](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/concepts.md)
+- [Extension 完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/extensions.md)
+- [Go SDK reference](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go/README.md)
+- [Go authentication と token](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go/AUTH-AND-TOKENS.md)
+- [Go feature parity](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go-feature-parity.md)
+- [WAM SDK](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM.md)
+
+## このアプリで確認できること
+
+- `github.com/channel-io/app-sdk/go` `v0.14.0`
+- SDK builder で登録する `command` Extension
+- Typed app Function と生成される JSON Schema
+- SDK-managed app/channel token cache と refresh
+- `/functions/:version` の SDK Gin server
+- `@channel.io/app-sdk-wam` `0.17.2` を使う React WAM
+- Go DTO と TypeScript WAM data を同時に検証する language-neutral JSON Schema
+- `@channel.io/bezier-react/beta` の Bezier 4 component
+
+Group chat で `/tutorial` Desk command を実行すると WAM が開きます。WAM は app bot または
+現在の manager authorization で team-chat message を送信します。対応しない chat type では
+silent close せず error state を表示します。
+
+コード上の基本概念は次の要素に対応します。
+
+- **Extension**: command builder が versioned `command` capability metadata を公開します。
+- **Function**: `tutorial.open` と `tutorial.sendAsBot` は command と WAM が参照する standalone typed operation です。
+- **WAM**: React UI は `/resource/wam/tutorial` で配信します。`useCallFunction` は app server、`useNativeFunction` は現在の manager として Channel を呼びます。
+- **認証**: SDK server が inbound signature を検証し、`native.TokenManager` が bot path の channel token を cache します。Server は許可済み group-chat target に短期 signature を付けて WAM に渡し、manager authorization は Channel host が管理します。
+
+Go SDK は token lifecycle を管理しますが、まだ `writeGroupMessage` typed proxy wrapper を
+提供していません。`internal/tutorial/native_message.go` はこの native Function だけを分離した
+transport adapter です。その他の token repository、command registrar、Function router は SDK
+が担当します。
+
+## SDK contract
+
+この tutorial は public SDK runtime contract に従います。
+
+- SDK-owned typed Function/Extension discovery
+- `PUT /functions/:version` と `/functions/v1`
+- Signature verification と SDK token lifecycle
+- Deploy 後の AppStore Extension registration
+- System version がない bare `PUT /functions` を同じ verified SDK handler に接続する限定的な compatibility route
+
+アプリは最新 Go SDK release を pin し、Function/WAM endpoint root を直接公開します。
+
+## 前提条件
+
+- Go 1.25
+- WAM 用 Node.js と Corepack 経由の Yarn 4
+- App ID、App Secret、Signing Key を持つ開発用 private Channel App
+
+アプリがまだない場合は SDK の
+[private app 準備手順](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/app-development.md#実装前に-private-app-を準備する)
+に従い、app creation、server-side credential storage、minimum permission、endpoint root、
+test channel installation を先に完了してください。
+
+**Authentication and permissions** で次の permission を有効にします。
+
+- Channel: `writeGroupMessage`
+- Manager: `writeGroupMessageAsManager`
+
+## 環境変数
+
+```sh
+cp .env.example .env
+```
+
+`APP_ID`、`APP_SECRET`、hex-encoded `SIGNING_KEY` を入力して現在の shell に読み込みます。
+
+```sh
+set -a
+. ./.env
+set +a
+```
+
+Secret を Git に commit しないでください。
+
+## HTTPS endpoint
+
+Local port `3022` に接続する HTTPS tunnel を準備し、developer portal に次の root を保存します。
+
+- Function Endpoint: `https://YOUR_HOST/functions`
+- WAM Endpoint: `https://YOUR_HOST/resource/wam`
+
+`/v1` や `/tutorial` を追加しません。Credential、permission、endpoint を server 起動後に
+変更した場合は、auto-registration を再実行するため server を restart してください。
+
+SDK route は versioned path を使います。現在の command execution は system version なしで
+設定済み Function Endpoint を呼ぶ場合があるため、tutorial は bare `PUT /functions` も同じ
+SDK handler と signature verification に接続します。
+
+## Build と実行
+
+```sh
+make build
+make run
+```
+
+検証済み test suite だけを実行できます。
+
+```sh
+make test
+```
+
+| Setting           | URL                                           |
+| ----------------- | --------------------------------------------- |
+| Function Endpoint | `https://YOUR_HOST/functions`                 |
+| WAM Endpoint      | `https://YOUR_HOST/resource/wam`              |
+| Health check      | `http://localhost:3022/ping`                  |
+| Local WAM         | `http://localhost:3022/resource/wam/tutorial` |
+
+Server startup と Extension registration が成功したら、test channel で private app を install
+または refresh し、group chat で `/tutorial` を実行してください。2 つの sender button と
+permission failure を確認します。`SKIP_SIGNATURE_VERIFICATION=true` は local debugging 以外で
+使用しないでください。
+
+## Project map
+
+```text
+cmd/main.go                         SDK server と Extension auto-registration
+cmd/function_endpoint.go            bare Function Endpoint compatibility route
+internal/tutorial/app.go           command metadata と typed app Function
+internal/tutorial/contracts.go     public WAM contract の Go type と name
+internal/tutorial/native_message.go 1 つの native transport adapter
+contracts/                         language-neutral WAM wire schema
+wam/src/contracts.ts               TypeScript view と runtime validation
+wam/src/pages/Send/Send.tsx         app/native call 用 WAM SDK hook
+```
+
+この tutorial と旧 Web 文書が異なる場合は、public SDK export、SDK reference、SDK guide、この
+実行例の順で確認してください。Go native transport gap は SDK feature-parity 文書で明記します。

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,141 @@
+# Channel App 튜토리얼 — Go
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+공식 [Channel App SDK](https://github.com/channel-io/app-sdk)로 만든 최소 end-to-end App Store
+앱입니다. SDK가 Function registry, schema, command Extension, versioned HTTP route,
+auto-registration, token lifecycle, request signature 검증을 담당합니다.
+
+이 저장소는 바로 실행할 수 있는 예제로 사용하고 계약과 설계 원칙은 SDK 문서를 확인하세요.
+
+- [앱 개발 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/app-development.md)
+- [Function, Extension, WAM, 인증 핵심 개념](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/concepts.md)
+- [Extension 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/extensions.md)
+- [Go SDK 레퍼런스](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go/README.md)
+- [Go 인증과 token](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go/AUTH-AND-TOKENS.md)
+- [Go 기능 동등성](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go-feature-parity.md)
+- [WAM SDK](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM.md)
+
+## 이 앱에서 확인할 수 있는 것
+
+- `github.com/channel-io/app-sdk/go` `v0.14.0`
+- SDK builder로 등록하는 `command` Extension
+- Typed app Function과 생성되는 JSON Schema
+- SDK가 관리하는 app/channel token cache와 refresh
+- `/functions/:version`의 SDK Gin server
+- `@channel.io/app-sdk-wam` `0.17.2`를 사용하는 React WAM
+- Go DTO와 TypeScript WAM data가 함께 검증하는 언어 중립 JSON Schema
+- `@channel.io/bezier-react/beta`의 Bezier 4 component
+
+그룹 대화에서 `/tutorial` Desk command를 실행하면 WAM이 열립니다. WAM은 app bot 또는 현재
+manager 권한으로 team-chat message를 보냅니다. 지원하지 않는 chat type에서는 조용히 닫지 않고
+오류 상태를 보여 줍니다.
+
+코드에서 핵심 개념은 다음과 대응합니다.
+
+- **Extension**: command builder가 versioned `command` capability metadata를 공개합니다.
+- **Function**: `tutorial.open`과 `tutorial.sendAsBot`은 command와 WAM이 참조하는 standalone typed operation입니다.
+- **WAM**: React UI는 `/resource/wam/tutorial`에서 제공됩니다. `useCallFunction`은 app server를, `useNativeFunction`은 현재 manager 주체로 Channel을 호출합니다.
+- **인증**: SDK server가 inbound signature를 검증하고 `native.TokenManager`가 bot 경로의 channel token을 cache합니다. Server는 허용된 group-chat target에 짧은 signature를 붙여 WAM에 전달하며 manager authorization은 Channel host가 관리합니다.
+
+Go SDK는 token lifecycle을 관리하지만 아직 `writeGroupMessage` typed proxy wrapper를 제공하지
+않습니다. `internal/tutorial/native_message.go`는 이 native Function 하나만 격리한 transport
+adapter입니다. 나머지 token repository, command registrar, Function router는 SDK가 담당합니다.
+
+## SDK 계약
+
+이 튜토리얼은 공개 SDK runtime 계약을 따릅니다.
+
+- SDK가 소유하는 typed Function/Extension discovery
+- `PUT /functions/:version`과 `/functions/v1`
+- Signature 검증과 SDK token lifecycle
+- Deploy 이후 AppStore Extension 등록
+- System version이 없는 bare `PUT /functions`를 같은 검증된 SDK handler로 연결하는 좁은 compatibility route
+
+앱은 최신 Go SDK release를 고정하고 Function/WAM endpoint root를 직접 제공합니다.
+
+## 준비 사항
+
+- Go 1.25
+- WAM용 Node.js와 Corepack 기반 Yarn 4
+- App ID, App Secret, Signing Key가 있는 개발용 private Channel App
+
+앱이 아직 없다면 SDK의
+[private app 준비 순서](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/app-development.md#구현-전에-private-app-준비하기)에
+따라 앱 생성, server-side credential 보관, 최소 permission, endpoint root, test channel 설치를
+먼저 완료하세요.
+
+**인증 및 권한** 설정에서 다음 permission을 활성화합니다.
+
+- Channel: `writeGroupMessage`
+- Manager: `writeGroupMessageAsManager`
+
+## 환경 변수
+
+```sh
+cp .env.example .env
+```
+
+`APP_ID`, `APP_SECRET`, hex-encoded `SIGNING_KEY`를 입력하고 현재 shell에 불러옵니다.
+
+```sh
+set -a
+. ./.env
+set +a
+```
+
+Secret을 Git에 commit하지 마세요.
+
+## HTTPS endpoint
+
+Local port `3022`를 연결하는 HTTPS tunnel을 준비하고 개발자 포털에 다음 root를 저장합니다.
+
+- Function Endpoint: `https://YOUR_HOST/functions`
+- WAM Endpoint: `https://YOUR_HOST/resource/wam`
+
+`/v1`이나 `/tutorial`을 덧붙이지 않습니다. Credential, permission, endpoint를 server 시작 뒤
+바꿨다면 auto-registration이 다시 실행되도록 server를 재시작하세요.
+
+SDK route는 versioned path를 사용합니다. 현재 command execution은 system version 없이 설정된
+Function Endpoint를 호출할 수 있으므로 튜토리얼은 bare `PUT /functions`도 같은 SDK handler와
+signature 검증으로 연결합니다.
+
+## Build와 실행
+
+```sh
+make build
+make run
+```
+
+검증된 test suite만 따로 실행할 수 있습니다.
+
+```sh
+make test
+```
+
+| 설정              | URL                                           |
+| ----------------- | --------------------------------------------- |
+| Function Endpoint | `https://YOUR_HOST/functions`                 |
+| WAM Endpoint      | `https://YOUR_HOST/resource/wam`              |
+| Health check      | `http://localhost:3022/ping`                  |
+| Local WAM         | `http://localhost:3022/resource/wam/tutorial` |
+
+Server가 시작되고 Extension 등록이 성공하면 test channel에서 private app을 설치하거나 새로고침한
+뒤 그룹 대화에서 `/tutorial`을 실행하세요. 두 sender button과 permission failure를 모두
+확인합니다. `SKIP_SIGNATURE_VERIFICATION=true`는 local debugging 밖에서 사용하지 마세요.
+
+## 프로젝트 구조
+
+```text
+cmd/main.go                         SDK server와 Extension auto-registration
+cmd/function_endpoint.go            bare Function Endpoint compatibility route
+internal/tutorial/app.go           command metadata와 typed app Function
+internal/tutorial/contracts.go     public WAM contract의 Go type과 name
+internal/tutorial/native_message.go 하나의 native transport adapter
+contracts/                         언어 중립 WAM wire schema
+wam/src/contracts.ts               TypeScript view와 runtime validation
+wam/src/pages/Send/Send.tsx         app/native call용 WAM SDK hook
+```
+
+이 튜토리얼과 오래된 웹 문서가 다르면 공개 SDK export, SDK reference, SDK guide, 이 실행 예제
+순서로 확인하세요. Go native transport gap은 SDK의 기능 동등성 문서에서 명시합니다.

--- a/README.md
+++ b/README.md
@@ -1,27 +1,32 @@
 # Channel App tutorial — Go
 
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
 A minimal Channel App Store app built with the official
-[Channel App SDK](https://github.com/channel-io/cht-app-sdk). The tutorial uses the SDK for the
+[Channel App SDK](https://github.com/channel-io/app-sdk). The tutorial uses the SDK for the
 function registry, schemas, command extension, versioned HTTP route, extension auto-registration,
 token lifecycle, and request-signature verification.
 
 Use this repository for a runnable end-to-end app. Use the SDK repository for the API contract and
 design guidance:
 
-- [English app-development guide](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/en/app-development.md)
-- [English concepts: Function, Extension, WAM, and authentication](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/en/concepts.md)
-- [한국어 앱 개발 전체 가이드](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ko/app-development.md)
-- [한국어 핵심 개념](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ko/concepts.md)
-- [日本語アプリ開発完全ガイド](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ja/app-development.md)
-- [日本語の基本概念](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/ja/concepts.md)
-- [Go feature parity](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/go-feature-parity.md)
-- [Go SDK reference](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/go/README.md)
-- [Go authentication and tokens](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/go/AUTH-AND-TOKENS.md)
-- [WAM SDK](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/WAM.md)
+- [English app-development guide](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/app-development.md)
+- [English concepts: Function, Extension, WAM, and authentication](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/concepts.md)
+- [English Extension guide](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/extensions.md)
+- [한국어 앱 개발 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/app-development.md)
+- [한국어 핵심 개념](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/concepts.md)
+- [한국어 Extension 전체 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ko/extensions.md)
+- [日本語アプリ開発完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/app-development.md)
+- [日本語の基本概念](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/concepts.md)
+- [日本語 Extension 完全ガイド](https://github.com/channel-io/app-sdk/blob/main/docs/guides/ja/extensions.md)
+- [Go feature parity](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go-feature-parity.md)
+- [Go SDK reference](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go/README.md)
+- [Go authentication and tokens](https://github.com/channel-io/app-sdk/blob/main/docs/reference/go/AUTH-AND-TOKENS.md)
+- [WAM SDK](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM.md)
 
 ## What this app demonstrates
 
-- `github.com/channel-io/cht-app-sdk/go` `v0.13.14`
+- `github.com/channel-io/app-sdk/go` `v0.14.0`
 - a `command` extension registered through the SDK builder
 - typed app functions and generated JSON schemas
 - SDK-managed app/channel token caching and refresh
@@ -46,21 +51,18 @@ The Go SDK currently owns the token lifecycle but does not yet expose a typed pr
 transport adapter for that one native function; the rest of the old hand-written AppStore client,
 token repository, command registrar, and function router has been removed.
 
-## Runtime contract alignment
+## SDK contract alignment
 
-Some managed builders scaffold TypeScript/NestJS projects rather than Go projects. This tutorial
-does not copy a builder-specific directory template, but it follows the same public runtime
-contract:
+This tutorial follows the public SDK runtime contract:
 
 - SDK-owned typed function and extension discovery
 - `PUT /functions/:version` (`/functions/v1` here)
 - signature verification and SDK token lifecycle
 - AppStore extension registration after deployment
-- a narrow ingress compatibility route from bare `PUT /functions` calls to the same SDK handler,
-  matching the managed runtime gateway when the caller does not carry a system version
+- a narrow ingress compatibility route from bare `PUT /functions` calls to the same verified SDK
+  handler when the caller does not carry a system version
 
-A managed platform may own deployment and endpoint sync for generated projects. This standalone Go
-app pins the latest Go SDK release and exposes the same function and WAM endpoint roots itself.
+This app pins the latest Go SDK release and exposes the Function and WAM endpoint roots directly.
 
 ## Prerequisites
 
@@ -69,7 +71,7 @@ app pins the latest Go SDK release and exposes the same function and WAM endpoin
 - a private Channel App with an App ID, App Secret, and Signing Key
 
 If you do not have an app yet, follow the SDK's
-[private-app preparation sequence](https://github.com/channel-io/cht-app-sdk/blob/main/docs/guides/en/app-development.md#prepare-a-private-app-before-coding): create a development app, keep credentials server-side, enable the minimum permissions below, prepare endpoint roots, and install it in a test channel.
+[private-app preparation sequence](https://github.com/channel-io/app-sdk/blob/main/docs/guides/en/app-development.md#prepare-a-private-app-before-coding): create a development app, keep credentials server-side, enable the minimum permissions below, prepare endpoint roots, and install it in a test channel.
 
 Enable these permissions in the app's **Authentication and permissions** settings:
 
@@ -105,7 +107,7 @@ server starts, restart the server so auto-registration runs again.
 
 The SDK route itself remains versioned. The tutorial also accepts bare `PUT /functions` through the
 same verified SDK handler because current command execution can call the configured Function
-Endpoint without a system-version suffix. Managed runtimes provide the same mapping at ingress.
+Endpoint without a system-version suffix. Both paths reuse the same signature verification.
 
 ## Build and run
 

--- a/cmd/function_endpoint.go
+++ b/cmd/function_endpoint.go
@@ -1,6 +1,6 @@
 package main
 
-import sdkgin "github.com/channel-io/cht-app-sdk/go/server/gin"
+import sdkgin "github.com/channel-io/app-sdk/go/server/gin"
 
 // mountAppStoreFunctionRoot keeps the SDK's versioned route as the source of
 // truth while accepting AppStore calls that target the configured root URL.

--- a/cmd/function_endpoint_test.go
+++ b/cmd/function_endpoint_test.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	sdkgin "github.com/channel-io/app-sdk/go/server/gin"
 	"github.com/channel-io/app-tutorial/internal/tutorial"
-	sdkgin "github.com/channel-io/cht-app-sdk/go/server/gin"
 )
 
 type compatibilitySender struct{}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -7,9 +7,9 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/channel-io/app-sdk/go/native"
+	sdkgin "github.com/channel-io/app-sdk/go/server/gin"
 	"github.com/channel-io/app-tutorial/internal/tutorial"
-	"github.com/channel-io/cht-app-sdk/go/native"
-	sdkgin "github.com/channel-io/cht-app-sdk/go/server/gin"
 	"github.com/gin-gonic/gin"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/channel-io/app-tutorial
 go 1.25.0
 
 require (
-	github.com/channel-io/cht-app-sdk/go v0.13.14
+	github.com/channel-io/app-sdk/go v0.14.0
 	github.com/gin-gonic/gin v1.10.1
 	google.golang.org/protobuf v1.36.11
 )

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/bytedance/sonic v1.11.6 h1:oUp34TzMlL+OY1OUWxHqsdkgC/Zfc85zGqw9siXjrc
 github.com/bytedance/sonic v1.11.6/go.mod h1:LysEHSvpvDySVdC2f87zGWf6CIKJcAvqab1ZaiQtds4=
 github.com/bytedance/sonic/loader v0.1.1 h1:c+e5Pt1k/cy5wMveRDyk2X4B9hF4g7an8N3zCYjJFNM=
 github.com/bytedance/sonic/loader v0.1.1/go.mod h1:ncP89zfokxS5LZrJxl5z0UJcsk4M4yY2JpfqGeCtNLU=
-github.com/channel-io/cht-app-sdk/go v0.13.14 h1:O4/4Rvea8sK56GUTCrk32kj7QWwKGhLDydqIQtDIMaE=
-github.com/channel-io/cht-app-sdk/go v0.13.14/go.mod h1:B4fV69Cv3VWfkG1lrasy9djVyBFgxji5F7mUNJALyUk=
+github.com/channel-io/app-sdk/go v0.14.0 h1:lmtHnhPXN3C4Pix+GGUk7v6tmpc1ThMz+kgEeIsVs9A=
+github.com/channel-io/app-sdk/go v0.14.0/go.mod h1:A/ATvjAeGsrttLIW6hn3ot63MjZ/kUZDw1FCGdPVNNk=
 github.com/cloudwego/base64x v0.1.4 h1:jwCgWpFanWmN8xoIUHa2rtzmkd5J2plF/dnLS6Xd/0Y=
 github.com/cloudwego/base64x v0.1.4/go.mod h1:0zlkT4Wn5C6NdauXdJRhSKRlJvmclQ1hhJgA0rcu/8w=
 github.com/cloudwego/iasm v0.2.0 h1:1KNIy1I1H9hNNFEEH3DVnI4UujN+1zjpuk6gwHLTssg=

--- a/internal/tutorial/app.go
+++ b/internal/tutorial/app.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/channel-io/cht-app-sdk/go/appsdk"
-	"github.com/channel-io/cht-app-sdk/go/extension/command"
+	"github.com/channel-io/app-sdk/go/appsdk"
+	"github.com/channel-io/app-sdk/go/extension/command"
 	"google.golang.org/protobuf/types/known/structpb"
 )
 

--- a/internal/tutorial/app_test.go
+++ b/internal/tutorial/app_test.go
@@ -5,7 +5,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/channel-io/cht-app-sdk/go/appsdk"
+	"github.com/channel-io/app-sdk/go/appsdk"
 )
 
 type fakeSender struct {

--- a/internal/tutorial/native_message.go
+++ b/internal/tutorial/native_message.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/channel-io/cht-app-sdk/go/native"
+	"github.com/channel-io/app-sdk/go/native"
 )
 
 type NativeMessageSender struct {

--- a/wam/README.ja.md
+++ b/wam/README.ja.md
@@ -1,0 +1,36 @@
+# WAM
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+この React frontend は WAM bridge に
+[`@channel.io/app-sdk-wam`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam)、
+WAM 専用 theme、navigation、state、高さ同期に
+[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam-ui)
+を使います。一般的な UI component は `@channel.io/bezier-react/beta` から直接 import します。
+
+`../contracts/tutorial-wam-data.schema.json` は Go server と WAM 間の public wire contract です。
+Go parity test が field と Function name を確認し、`src/contracts.ts` が Function call を
+有効にする前に host data を validation します。Channel API access token と server-only runtime
+type は共有しません。
+
+Example は Bezier React `4.0.0-next.13` と Bezier Icons `0.60.0` を固定します。Bezier React 4
+はまだ prerelease なので version を明示的に pin し、upgrade 前に
+[SDK WAM UI guide](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)
+を確認してください。
+
+## Development
+
+```sh
+corepack yarn install --immutable
+corepack yarn dev
+```
+
+WAM を build して typecheck します。
+
+```sh
+corepack yarn build
+corepack yarn typecheck
+```
+
+Build output は `dist/` に生成され、Go tutorial server が
+`/resource/wam/tutorial` で配信します。

--- a/wam/README.ko.md
+++ b/wam/README.ko.md
@@ -1,0 +1,35 @@
+# WAM
+
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
+이 React frontend는 WAM bridge에
+[`@channel.io/app-sdk-wam`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam)을,
+WAM 전용 theme, navigation, 상태 화면, 높이 동기화에
+[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam-ui)를
+사용합니다. 일반 UI component는 `@channel.io/bezier-react/beta`에서 직접 가져옵니다.
+
+`../contracts/tutorial-wam-data.schema.json`은 Go server와 WAM 사이의 공개 wire contract입니다.
+Go parity test가 field와 Function name을 확인하고 `src/contracts.ts`가 Function call을 활성화하기
+전에 host data를 검증합니다. Channel API 접근 token과 server-only runtime type은 공유하지 않습니다.
+
+예제는 Bezier React `4.0.0-next.13`과 Bezier Icons `0.60.0`을 고정합니다. Bezier React 4는
+아직 prerelease이므로 버전을 명시적으로 고정하고 upgrade 전에
+[SDK WAM UI 가이드](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)를
+확인하세요.
+
+## 개발
+
+```sh
+corepack yarn install --immutable
+corepack yarn dev
+```
+
+WAM을 build하고 typecheck합니다.
+
+```sh
+corepack yarn build
+corepack yarn typecheck
+```
+
+Build 결과는 `dist/`에 생성되고 Go tutorial server가
+`/resource/wam/tutorial`에서 제공합니다.

--- a/wam/README.md
+++ b/wam/README.md
@@ -1,9 +1,11 @@
 # WAM
 
+[English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
+
 This React frontend uses
-[`@channel.io/app-sdk-wam`](https://github.com/channel-io/cht-app-sdk/tree/main/ts/packages/wam)
+[`@channel.io/app-sdk-wam`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam)
 for the WAM bridge and
-[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/cht-app-sdk/tree/main/ts/packages/wam-ui)
+[`@channel.io/app-sdk-wam-ui`](https://github.com/channel-io/app-sdk/tree/main/ts/packages/wam-ui)
 for WAM-specific theming, navigation, states, and content-height synchronization. Import
 general-purpose UI components directly from `@channel.io/bezier-react/beta`.
 
@@ -14,7 +16,7 @@ to access Channel APIs, and server-only runtime types are not shared.
 
 The example pins Bezier React `4.0.0-next.13` and Bezier Icons `0.60.0`. Bezier React 4 is still a
 prerelease, so keep the selected version explicit and check the
-[SDK WAM UI guide](https://github.com/channel-io/cht-app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)
+[SDK WAM UI guide](https://github.com/channel-io/app-sdk/blob/main/docs/reference/typescript/WAM-UI.md)
 before upgrading it.
 
 ## Development


### PR DESCRIPTION
## Summary
- migrate all Go imports and go.mod to github.com/channel-io/app-sdk/go v0.14.0
- switch documentation links to channel-io/app-sdk
- add complete Korean and Japanese Go tutorial and WAM guides
- remove platform-specific runtime wording and link localized Extension guides

## Test Plan
- [x] Go 1.25.12 build
- [x] go test ./...
- [x] WAM build
- [x] Yarn format, lint, and typecheck
- [x] Prettier and public-name audit